### PR TITLE
983192-Remove unwanted assembly in WPF sample browser presentation

### DIFF
--- a/presentation/syncfusion.presentationdemos.wpf.csproj
+++ b/presentation/syncfusion.presentationdemos.wpf.csproj
@@ -39,9 +39,6 @@
     <Compile Remove="Views\*" />
     <Compile Remove="PresentationDemosViewModel.cs" />
 
-    <Reference Include="Syncfusion.Chart.WPF.SampleLayout">
-      <HintPath>$(SyncfusionInstallLocation)\precompiledassemblies\$(TargetFramework)\Syncfusion.Chart.WPF.SampleLayout.dll</HintPath>
-    </Reference>
     <Reference Include="Syncfusion.Compression.Base">
       <HintPath>$(SyncfusionInstallLocation)\precompiledassemblies\$(TargetFramework)\Syncfusion.Compression.Base.dll</HintPath>
     </Reference>

--- a/presentation/syncfusion.presentationdemos.wpf_47.csproj
+++ b/presentation/syncfusion.presentationdemos.wpf_47.csproj
@@ -37,8 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="PresentationFramework.Aero" />
-    <Reference Include="Syncfusion.Chart.WPF.SampleLayout">
-    </Reference>
     <Reference Include="Syncfusion.Compression.Base" />
     <Reference Include="Syncfusion.OfficeChart.Base">
     </Reference>


### PR DESCRIPTION
Hi All,

Remove below assembly from presentation.
1. Syncfusion.Chart.WPF.SampleLayout

Thanks,
Sivakumar. A